### PR TITLE
Fix normalizedAmount jasmine test

### DIFF
--- a/src/coffee/test/donation-form-spec.coffee
+++ b/src/coffee/test/donation-form-spec.coffee
@@ -82,7 +82,7 @@ describe "DonationsFormModel", ->
     # Note: the BBD is pegged to the USD at 0.5 BBD to 1 USD
 
     it "should convert displayed amounts to normalized amounts", ->
-      formWithConversion.inputtedAmount = 10
+      formWithConversion.inputtedAmount(10)
       formWithConversion.currency = 'USD'
       expect(formWithConversion.normalizedAmount()).toEqual('1000')
 


### PR DESCRIPTION
It looks like this test was failing because the inputtedAmount was not getting set as expected, causing the displayAmount to be null.
